### PR TITLE
feat: Add PWA support with installability and offline caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,26 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/icons/icon-192x192.svg" />
+    <link rel="apple-touch-icon" href="/icons/icon-192x192.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Buy, sell, and trade vouchers at discounted prices" />
+    <meta name="theme-color" content="#14b8a6" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="VoucherX" />
+    <link rel="manifest" href="/manifest.json" />
     <title>VoucherX</title>
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/sw.js').catch(() => {});
+        });
+      }
+    </script>
   </body>
 </html>

--- a/public/icons/icon-192x192.svg
+++ b/public/icons/icon-192x192.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="24" fill="#14b8a6"/>
+  <g transform="translate(32, 32)" fill="none" stroke="#ffffff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="16" y="16" width="96" height="64" rx="8"/>
+    <circle cx="88" cy="48" r="12"/>
+    <line x1="16" y1="32" x2="16" y2="64"/>
+    <path d="M40 96 L64 112 L88 96"/>
+    <line x1="64" y1="72" x2="64" y2="80"/>
+    <circle cx="36" cy="48" r="4" fill="#ffffff"/>
+  </g>
+</svg>

--- a/public/icons/icon-512x512.svg
+++ b/public/icons/icon-512x512.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="64" fill="#14b8a6"/>
+  <g transform="translate(96, 96)" fill="none" stroke="#ffffff" stroke-width="14" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="40" y="40" width="240" height="160" rx="20"/>
+    <circle cx="220" cy="120" r="32"/>
+    <line x1="40" y1="80" x2="40" y2="160"/>
+    <path d="M100 240 L160 280 L220 240"/>
+    <line x1="160" y1="180" x2="160" y2="200"/>
+    <circle cx="92" cy="120" r="10" fill="#ffffff"/>
+  </g>
+</svg>

--- a/public/icons/icon-maskable-192x192.svg
+++ b/public/icons/icon-maskable-192x192.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" fill="#14b8a6"/>
+  <g transform="translate(32, 32)" fill="none" stroke="#ffffff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="16" y="16" width="96" height="64" rx="8"/>
+    <circle cx="88" cy="48" r="12"/>
+    <line x1="16" y1="32" x2="16" y2="64"/>
+    <path d="M40 96 L64 112 L88 96"/>
+    <line x1="64" y1="72" x2="64" y2="80"/>
+    <circle cx="36" cy="48" r="4" fill="#ffffff"/>
+  </g>
+</svg>

--- a/public/icons/icon-maskable-512x512.svg
+++ b/public/icons/icon-maskable-512x512.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#14b8a6"/>
+  <g transform="translate(96, 96)" fill="none" stroke="#ffffff" stroke-width="14" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="40" y="40" width="240" height="160" rx="20"/>
+    <circle cx="220" cy="120" r="32"/>
+    <line x1="40" y1="80" x2="40" y2="160"/>
+    <path d="M100 240 L160 280 L220 240"/>
+    <line x1="160" y1="180" x2="160" y2="200"/>
+    <circle cx="92" cy="120" r="10" fill="#ffffff"/>
+  </g>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,40 @@
+{
+  "name": "VoucherX",
+  "short_name": "VoucherX",
+  "description": "Buy, sell, and trade vouchers at discounted prices",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#14b8a6",
+  "orientation": "any",
+  "scope": "/",
+  "icons": [
+    {
+      "src": "/icons/icon-192x192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/icon-512x512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/icon-maskable-192x192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    },
+    {
+      "src": "/icons/icon-maskable-512x512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ],
+  "categories": ["shopping", "finance"],
+  "screenshots": [],
+  "prefer_related_applications": false
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,74 @@
+const CACHE_NAME = 'voucherx-v1';
+const STATIC_ASSETS = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+  '/icons/icon-192x192.svg',
+  '/icons/icon-512x512.svg',
+];
+
+// Install: cache static assets
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => {
+      return cache.addAll(STATIC_ASSETS);
+    })
+  );
+  self.skipWaiting();
+});
+
+// Activate: clean up old caches
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) => {
+      return Promise.all(
+        cacheNames
+          .filter((name) => name !== CACHE_NAME)
+          .map((name) => caches.delete(name))
+      );
+    })
+  );
+  self.clients.claim();
+});
+
+// Fetch: network-first strategy for API calls, cache-first for static assets
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Skip non-GET requests
+  if (request.method !== 'GET') return;
+
+  // Skip cross-origin requests (e.g., Supabase API)
+  if (url.origin !== location.origin) return;
+
+  // Network-first for HTML navigation requests
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const cloned = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, cloned));
+          return response;
+        })
+        .catch(() => caches.match(request) || caches.match('/index.html'))
+    );
+    return;
+  }
+
+  // Cache-first for static assets
+  event.respondWith(
+    caches.match(request).then((cachedResponse) => {
+      if (cachedResponse) return cachedResponse;
+
+      return fetch(request).then((response) => {
+        // Only cache successful responses
+        if (!response || response.status !== 200) return response;
+
+        const cloned = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(request, cloned));
+        return response;
+      });
+    })
+  );
+});


### PR DESCRIPTION
## Summary

Adds Progressive Web App (PWA) support to VoucherX, enabling installability on mobile and desktop devices with offline caching for a better mobile experience.

Closes #45

## Files Added/Modified

| File | Purpose |
|------|---------|
| `public/manifest.json` | Web app manifest with name, theme color, icons, and `standalone` display mode |
| `public/sw.js` | Service worker with offline caching strategies |
| `public/icons/icon-192x192.svg` | App icon (192x192, regular purpose) |
| `public/icons/icon-512x512.svg` | App icon (512x512, regular purpose) |
| `public/icons/icon-maskable-192x192.svg` | Maskable icon for adaptive icon support (192x192) |
| `public/icons/icon-maskable-512x512.svg` | Maskable icon for adaptive icon support (512x512) |
| `index.html` | Updated with PWA meta tags, manifest link, and service worker registration |

## PWA Features

### Manifest (`manifest.json`)
- **Name**: VoucherX
- **Display**: `standalone` — launches without browser UI when installed
- **Theme color**: `#14b8a6` (teal) — matches the app's branding
- **Icons**: SVG icons at 192x192 and 512x512, both regular and maskable variants
- **Categories**: shopping, finance

### Service Worker (`sw.js`)
- **Install**: Pre-caches core static assets (index.html, manifest, icons)
- **Activate**: Cleans up old caches on version updates
- **Fetch strategies**:
  - **Network-first** for navigation requests (HTML pages) — falls back to cache if offline
  - **Cache-first** for static assets (JS, CSS, images) — falls back to network for uncached assets
  - **Skip** non-GET and cross-origin requests (e.g., Supabase API calls)

### HTML Updates (`index.html`)
- `<meta name="theme-color">` — colors the browser/status bar on mobile
- `<meta name="apple-mobile-web-app-capable">` — enables Add to Home Screen on iOS
- `<meta name="apple-mobile-web-app-status-bar-style">` — iOS status bar styling
- `<meta name="apple-mobile-web-app-title">` — app title on iOS home screen
- `<meta name="description">` — app description for SEO and install prompts
- `<link rel="manifest">` — links the web app manifest
- `<link rel="apple-touch-icon">` — iOS home screen icon
- Service worker registration script on window load

## What This Enables

- **Install prompt** on Chrome, Edge, Safari (Add to Home Screen)
- **Standalone app window** without browser chrome
- **Offline support** for cached pages and assets
- **Themed status bar** on Android and iOS
- **App icon** on home screen with maskable support for adaptive icons
