### PR TITLE
fix(ui): resolve navbar horizontal overflow on medium screens (fixes #101)

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -36,7 +36,7 @@ export default function Layout({ children, currentPage, onNavigate, onOpenAI }: 
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-teal-50">
-      <nav className="bg-white/80 backdrop-blur-md border-b border-slate-200 sticky top-0 z-50">
+      <nav className="bg-white/80 backdrop-blur-md border-b border-slate-200 sticky top-0 z-50 overflow-x-hidden">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center space-x-8">
@@ -52,7 +52,7 @@ export default function Layout({ children, currentPage, onNavigate, onOpenAI }: 
                 </span>
               </button>
 
-              <div className="hidden md:flex space-x-1 lg:space-x-2">
+              <div className="hidden lg:flex space-x-1 xl:space-x-2">
                 {navItems.map(item => {
                   const Icon = item.icon;
                   const isActive = currentPage === item.id;
@@ -60,7 +60,7 @@ export default function Layout({ children, currentPage, onNavigate, onOpenAI }: 
                     <button
                       key={item.id}
                       onClick={() => onNavigate(item.id)}
-                      className={`px-3 py-2 lg:px-4 rounded-lg flex items-center space-x-1.5 lg:space-x-2 transition-all ${isActive
+                      className={`px-3 py-2 xl:px-4 rounded-lg flex items-center space-x-1.5 xl:space-x-2 transition-all ${isActive
                         ? 'bg-gradient-to-r from-teal-500 to-blue-600 text-white shadow-md'
                         : 'text-slate-600 hover:bg-slate-100'
                         }`}
@@ -74,7 +74,7 @@ export default function Layout({ children, currentPage, onNavigate, onOpenAI }: 
             </div>
 
             <div className="flex items-center space-x-4">
-              <div className="hidden md:flex items-center bg-gradient-to-r from-amber-50 to-orange-50 border border-amber-100 rounded-full px-4 py-1.5 shadow-sm space-x-2">
+              <div className="hidden lg:flex items-center bg-gradient-to-r from-amber-50 to-orange-50 border border-amber-100 rounded-full px-4 py-1.5 shadow-sm space-x-2">
                 <Star className="h-4 w-4 text-amber-500 fill-amber-500" />
                 <span className="text-sm font-bold text-amber-700 whitespace-nowrap">
                   {profile?.voucher_coins?.toLocaleString() || 0} Coins
@@ -90,7 +90,7 @@ export default function Layout({ children, currentPage, onNavigate, onOpenAI }: 
                 <span className="absolute top-1 right-1 w-2 h-2 bg-purple-500 rounded-full animate-pulse"></span>
               </button>
 
-              <div className="hidden md:flex items-center space-x-3">
+              <div className="hidden lg:flex items-center space-x-3">
                 <button
                   onClick={() => onNavigate('profile')}
                   className="flex items-center space-x-2 hover:bg-slate-100 rounded-full px-3 py-2 transition-colors"
@@ -110,7 +110,7 @@ export default function Layout({ children, currentPage, onNavigate, onOpenAI }: 
 
               <button
                 onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-                className="md:hidden p-2 text-slate-600 hover:bg-slate-100 rounded-lg"
+                className="lg:hidden p-2 text-slate-600 hover:bg-slate-100 rounded-lg"
               >
                 {mobileMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
               </button>
@@ -119,7 +119,7 @@ export default function Layout({ children, currentPage, onNavigate, onOpenAI }: 
         </div>
 
         {mobileMenuOpen && (
-          <div className="md:hidden border-t border-slate-200 bg-white">
+          <div className="lg:hidden border-t border-slate-200 bg-white">
             <div className="px-4 py-4 space-y-2">
               {navItems.map(item => {
                 const Icon = item.icon;


### PR DESCRIPTION
## Summary

Fixes the navbar horizontal overflow that occurs at screen widths around 925px (medium screens / tablets / small laptops).

Fixes #101

## Root Cause

The desktop navigation items, coins badge, profile, and logout button all used Tailwind's `md` breakpoint (768px) to become visible. With 7 nav items plus right-side elements, there isn't enough horizontal space between 768–1024px, causing content to overflow the viewport.

## Fix

- **Shifted the desktop nav breakpoint from `md` (768px) to `lg` (1024px)**
- The hamburger/slide-out menu now covers the entire 0–1024px range
- Adjusted inner spacing utilities from `lg:` to `xl:` for comfortable fit at larger screens
- Added `overflow-x-hidden` on the `<nav>` element as an extra safeguard

### Specific class changes in `Layout.tsx`

| Element | Before | After |
|---------|--------|-------|
| Nav items container | `hidden md:flex` | `hidden lg:flex` |
| Nav item spacing | `lg:space-x-2`, `lg:px-4` | `xl:space-x-2`, `xl:px-4` |
| Coins badge | `hidden md:flex` | `hidden lg:flex` |
| Profile / Logout | `hidden md:flex` | `hidden lg:flex` |
| Hamburger button | `md:hidden` | `lg:hidden` |
| Mobile menu panel | `md:hidden` | `lg:hidden` |
| Nav element | — | Added `overflow-x-hidden` |

## Testing

1. Resize browser to ~925px → no horizontal scrollbar, hamburger menu appears
2. At 1024px+ → full desktop nav renders without overflow
3. Mobile menu includes all nav items, coins, profile, assistant, and sign out
