### PR TITLE
docs: add Contributors section and Table of Contents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,26 @@ VoucherX is a modern web application that enables users to trade, buy, and sell 
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.5.3-3178C6?logo=typescript)
 ![Supabase](https://img.shields.io/badge/Supabase-2.57.4-3ECF8E?logo=supabase)
 
+## 📋 Table of Contents
+
+- [Features](#-features)
+- [Quick Start](#-quick-start)
+- [Project Structure](#-project-structure)
+- [Database Schema](#️-database-schema)
+- [Tech Stack](#-tech-stack)
+- [Key Features Explained](#-key-features-explained)
+- [Security Features](#-security-features)
+- [Available Scripts](#-available-scripts)
+- [Deployment](#-deployment)
+- [Contributing](#-contributing)
+- [Environment Variables](#-environment-variables)
+- [Troubleshooting](#-troubleshooting)
+- [Documentation](#-documentation)
+- [Roadmap](#-roadmap)
+- [Contributors](#-contributors)
+- [License](#-license)
+- [Support](#-support)
+
 ## 🌟 Features
 
 ### Core Features
@@ -281,13 +301,23 @@ For detailed documentation on specific features:
 - [ ] Auction system for rare vouchers
 - [ ] Referral program
 
-## 📄 License
+## � Contributors
+
+Thanks to all the amazing people who have contributed to VoucherX! 🎉
+
+<a href="https://github.com/jaiashwinisatish/VoucherX/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=jaiashwinisatish/VoucherX" alt="VoucherX Contributors" />
+</a>
+
+Want to see your face here? Check out our [Contributing Guide](#-contributing) and submit a PR!
+
+## �📄 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
-## 👥 Authors
+## � Author
 
-- Your Name - [GitHub](https://github.com/yourusername)
+- **jaiashwinisatish** - Project Owner - [GitHub](https://github.com/jaiashwinisatish)
 
 ## 🙏 Acknowledgments
 


### PR DESCRIPTION
## Summary

Adds a Contributors section and Table of Contents to the README to recognize contributors and improve documentation navigation.

Closes #97

## Changes

### Table of Contents
Added a `📋 Table of Contents` section after the badges with anchor links to all major README sections, making it easy to navigate the documentation.

### Contributors Section
Added a `👥 Contributors` section before the License section that includes:
- Auto-generated contributor avatar grid via [contrib.rocks](https://contrib.rocks)
- Link to the full [GitHub contributors graph](https://github.com/jaiashwinisatish/VoucherX/graphs/contributors)
- Call-to-action encouraging new contributors to submit PRs

The contrib.rocks image automatically updates as new contributors join, so no manual maintenance is needed.

### Author Section
- Updated `Authors` → `Author` (singular) with the project owner's actual GitHub profile link

### What's Preserved
- All existing README content remains intact
- No structural changes to existing sections
- Formatting consistency maintained throughout

## Preview

The contributors section renders as:

> **👥 Contributors**
>
> Thanks to all the amazing people who have contributed to VoucherX! 🎉
>
> *(auto-generated contributor avatars)*
>
> Want to see your face here? Check out our Contributing Guide and submit a PR!
