### PR TITLE
feat(ui): add brand logos to voucher cards for better visual appeal

### DIFF
--- a/src/components/BrandLogo.tsx
+++ b/src/components/BrandLogo.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react';
+
+/**
+ * Maps common brand names to their domain for logo fetching.
+ * Uses logo.clearbit.com as a free, high-quality logo API.
+ */
+const BRAND_DOMAINS: Record<string, string> = {
+  amazon: 'amazon.com',
+  starbucks: 'starbucks.com',
+  nike: 'nike.com',
+  uber: 'uber.com',
+  spotify: 'spotify.com',
+  netflix: 'netflix.com',
+  apple: 'apple.com',
+  google: 'google.com',
+  walmart: 'walmart.com',
+  target: 'target.com',
+  'best buy': 'bestbuy.com',
+  bestbuy: 'bestbuy.com',
+  adidas: 'adidas.com',
+  zara: 'zara.com',
+  sephora: 'sephora.com',
+  nordstrom: 'nordstrom.com',
+  ikea: 'ikea.com',
+  costco: 'costco.com',
+  'home depot': 'homedepot.com',
+  mcdonald: 'mcdonalds.com',
+  mcdonalds: 'mcdonalds.com',
+  "mcdonald's": 'mcdonalds.com',
+  'pizza hut': 'pizzahut.com',
+  dominos: 'dominos.com',
+  "domino's": 'dominos.com',
+  'dunkin donuts': 'dunkindonuts.com',
+  dunkin: 'dunkindonuts.com',
+  chipotle: 'chipotle.com',
+  'taco bell': 'tacobell.com',
+  subway: 'subway.com',
+  hulu: 'hulu.com',
+  disney: 'disney.com',
+  hbo: 'hbo.com',
+  playstation: 'playstation.com',
+  xbox: 'xbox.com',
+  steam: 'steampowered.com',
+  twitch: 'twitch.tv',
+  airbnb: 'airbnb.com',
+  lyft: 'lyft.com',
+  doordash: 'doordash.com',
+  grubhub: 'grubhub.com',
+  instacart: 'instacart.com',
+  ebay: 'ebay.com',
+  etsy: 'etsy.com',
+  shopify: 'shopify.com',
+  visa: 'visa.com',
+  mastercard: 'mastercard.com',
+  paypal: 'paypal.com',
+};
+
+/**
+ * Generates a consistent color based on the brand name string for the fallback avatar.
+ */
+function getBrandColor(brandName: string): string {
+  const colors = [
+    'from-teal-500 to-emerald-600',
+    'from-blue-500 to-indigo-600',
+    'from-purple-500 to-pink-600',
+    'from-amber-500 to-orange-600',
+    'from-rose-500 to-red-600',
+    'from-cyan-500 to-blue-600',
+    'from-emerald-500 to-teal-600',
+    'from-indigo-500 to-purple-600',
+    'from-orange-500 to-amber-600',
+    'from-pink-500 to-rose-600',
+  ];
+
+  let hash = 0;
+  for (let i = 0; i < brandName.length; i++) {
+    hash = brandName.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return colors[Math.abs(hash) % colors.length];
+}
+
+/**
+ * Resolves the logo URL for a given brand name.
+ * Uses logo.clearbit.com which provides free, high-quality brand logos.
+ */
+export function getBrandLogoUrl(brandName: string): string | null {
+  const normalized = brandName.toLowerCase().trim();
+  const domain = BRAND_DOMAINS[normalized];
+  if (domain) {
+    return `https://logo.clearbit.com/${domain}`;
+  }
+  // Fallback: try using the brand name directly as a domain
+  const sanitized = normalized.replace(/[^a-z0-9]/g, '');
+  return `https://logo.clearbit.com/${sanitized}.com`;
+}
+
+interface BrandLogoProps {
+  brandName: string;
+  /** Size variant: 'sm' (32px), 'md' (48px), 'lg' (64px) */
+  size?: 'sm' | 'md' | 'lg';
+  /** Additional CSS classes */
+  className?: string;
+}
+
+const sizeClasses = {
+  sm: 'w-8 h-8',
+  md: 'w-12 h-12',
+  lg: 'w-16 h-16',
+};
+
+const textSizes = {
+  sm: 'text-xs',
+  md: 'text-sm',
+  lg: 'text-lg',
+};
+
+/**
+ * BrandLogo component displays a brand's official logo with a styled fallback.
+ *
+ * - Fetches logos from logo.clearbit.com (free API)
+ * - Shows a gradient initial avatar as fallback if the logo fails to load
+ * - Responsive and consistent sizing across all card layouts
+ */
+export default function BrandLogo({ brandName, size = 'md', className = '' }: BrandLogoProps) {
+  const [hasError, setHasError] = useState(false);
+  const logoUrl = getBrandLogoUrl(brandName);
+  const initial = brandName.charAt(0).toUpperCase();
+  const gradientColor = getBrandColor(brandName);
+
+  if (hasError || !logoUrl) {
+    return (
+      <div
+        className={`${sizeClasses[size]} rounded-xl bg-gradient-to-br ${gradientColor} flex items-center justify-center flex-shrink-0 shadow-sm ${className}`}
+        title={brandName}
+        aria-label={`${brandName} logo`}
+      >
+        <span className={`${textSizes[size]} font-bold text-white`}>{initial}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`${sizeClasses[size]} rounded-xl bg-white border border-slate-200 flex items-center justify-center flex-shrink-0 overflow-hidden shadow-sm ${className}`}
+      title={brandName}
+      aria-label={`${brandName} logo`}
+    >
+      <img
+        src={logoUrl}
+        alt={`${brandName} logo`}
+        className="w-[75%] h-[75%] object-contain"
+        onError={() => setHasError(true)}
+        loading="lazy"
+      />
+    </div>
+  );
+}

--- a/src/pages/Exchange.tsx
+++ b/src/pages/Exchange.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Repeat, Sparkles, TrendingUp, ArrowRight, Star, Check } from 'lucide-react';
 import { Voucher } from '../types';
+import BrandLogo from '../components/BrandLogo';
 
 interface ExchangeProps {
   onNavigate: (page: string) => void;
@@ -169,9 +170,12 @@ export default function Exchange({ onNavigate }: ExchangeProps) {
                   }`}
                 >
                   <div className="flex items-start justify-between mb-4">
-                    <div>
-                      <h3 className="text-xl font-semibold text-slate-800">{voucher.brand_name}</h3>
-                      <p className="text-sm text-slate-600">{voucher.category}</p>
+                    <div className="flex items-center space-x-3">
+                      <BrandLogo brandName={voucher.brand_name} size="md" />
+                      <div>
+                        <h3 className="text-xl font-semibold text-slate-800">{voucher.brand_name}</h3>
+                        <p className="text-sm text-slate-600">{voucher.category}</p>
+                      </div>
                     </div>
                     {voucher.is_verified && (
                       <div className="bg-emerald-500 text-white px-2 py-1 rounded-full text-xs font-semibold flex items-center space-x-1">
@@ -234,6 +238,7 @@ export default function Exchange({ onNavigate }: ExchangeProps) {
                   <div className="flex items-start justify-between mb-4">
                     <div className="flex-1">
                       <div className="flex items-center space-x-3 mb-2">
+                        <BrandLogo brandName={match.brand_name} size="md" />
                         <h3 className="text-2xl font-semibold text-slate-800">{match.brand_name}</h3>
                         <div className="bg-gradient-to-r from-amber-500 to-orange-500 text-white px-3 py-1 rounded-full text-xs font-semibold flex items-center space-x-1">
                           <TrendingUp className="h-3 w-3" />

--- a/src/pages/ExpiryInsights.tsx
+++ b/src/pages/ExpiryInsights.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { supabase } from "../lib/supabase";
+import BrandLogo from "../components/BrandLogo";
 import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
 
@@ -126,9 +127,12 @@ export default function ExpiryInsights() {
                       key={v.id}
                       className="bg-gray-50 border p-4 rounded-lg shadow-sm mb-3"
                     >
-                      <p className="font-semibold">
-                        {v.brand_name}
-                      </p>
+                      <div className="flex items-center space-x-3 mb-1">
+                        <BrandLogo brandName={v.brand_name} size="sm" />
+                        <p className="font-semibold">
+                          {v.brand_name}
+                        </p>
+                      </div>
                       <p className="text-sm text-gray-600">
                         Value: ₹{v.original_value}
                       </p>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 
 import { TrendingUp, Star, Tag, Calendar, Eye, Bot } from 'lucide-react';
 import { Voucher } from '../types';
+import BrandLogo from '../components/BrandLogo';
 
 interface HomeProps {
   onNavigate: (page: string) => void;
@@ -219,8 +220,9 @@ export default function Home({ onNavigate, onOpenAI }: HomeProps) {
 "
               >
                 <div className="relative h-48 bg-gradient-to-br from-slate-100 to-slate-200 p-6 flex items-center justify-center">
-                  <div className="text-center">
-                    <div className="text-5xl font-bold bg-gradient-to-r from-teal-600 to-blue-600 bg-clip-text text-transparent mb-2">
+                  <div className="text-center flex flex-col items-center">
+                    <BrandLogo brandName={voucher.brand_name} size="lg" className="mb-3" />
+                    <div className="text-3xl font-bold bg-gradient-to-r from-teal-600 to-blue-600 bg-clip-text text-transparent mb-2">
                       {voucher.brand_name}
                     </div>
                     <div className="inline-block bg-white/80 backdrop-blur-sm px-4 py-1 rounded-full text-sm font-medium text-slate-700">

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Search, Filter, Tag, Star, Calendar, Eye, ShoppingCart, AlertCircle } from 'lucide-react';
 import { Voucher } from '../types';
+import BrandLogo from '../components/BrandLogo';
 import { hasInvalidSupabaseConfig, supabase } from '../lib/supabase';
 import { useCategories } from '../hooks/useCategories';
 
@@ -366,8 +367,11 @@ export default function Marketplace({ onNavigate }: MarketplaceProps) {
                 className="bg-white/80 backdrop-blur-sm rounded-xl border border-slate-200 hover:shadow-xl hover:scale-105 transition-all overflow-hidden group"
               >
                 <div className="relative h-40 bg-gradient-to-br from-slate-100 to-slate-200 p-6 flex items-center justify-center">
-                  <div className="text-4xl font-bold bg-gradient-to-r from-teal-600 to-blue-600 bg-clip-text text-transparent">
-                    {voucher.brand_name}
+                  <div className="flex flex-col items-center">
+                    <BrandLogo brandName={voucher.brand_name} size="lg" className="mb-2" />
+                    <div className="text-2xl font-bold bg-gradient-to-r from-teal-600 to-blue-600 bg-clip-text text-transparent">
+                      {voucher.brand_name}
+                    </div>
                   </div>
 
                   {voucher.is_verified && (

--- a/src/pages/Wallet.tsx
+++ b/src/pages/Wallet.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Wallet as WalletIcon, Star, Calendar, CheckCircle, Clock, Copy, Tag } from 'lucide-react';
 import { Voucher } from '../types';
+import BrandLogo from '../components/BrandLogo';
 
 const activeVouchers: Voucher[] = [
   {
@@ -189,6 +190,7 @@ export default function Wallet() {
                 <div className="flex items-start justify-between mb-4">
                   <div className="flex-1">
                     <div className="flex items-center flex-wrap gap-3 mb-2">
+                      <BrandLogo brandName={voucher.brand_name} size="md" />
                       <h3 className="text-2xl font-bold text-slate-800">{voucher.brand_name}</h3>
                       {voucher.is_verified && (
                         <div className="bg-emerald-500 text-white px-3 py-1 rounded-full text-xs font-semibold flex items-center space-x-1">

--- a/src/pages/Wishlist.tsx
+++ b/src/pages/Wishlist.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Heart, Plus, Bell, BellOff, X, Trash2, Loader } from 'lucide-react';
 import { supabase } from '../lib/supabase';
+import BrandLogo from '../components/BrandLogo';
 import { useAuth } from '../contexts/AuthContext';
 import { WishlistItem } from '../types';
 import { useCategories } from '../hooks/useCategories';
@@ -237,6 +238,7 @@ export default function Wishlist() {
               <div className="flex items-start justify-between mb-4">
                 <div className="flex-1">
                   <div className="flex items-center space-x-2 mb-3">
+                    <BrandLogo brandName={item.brand_name} size="sm" />
                     <h3 className="text-xl font-semibold text-slate-800">{item.brand_name}</h3>
                     <Heart className="h-5 w-5 text-pink-600 fill-pink-600" />
                   </div>


### PR DESCRIPTION
## Summary

Adds official brand logos to voucher cards across the entire application for better visual appeal and brand recognition.

Closes #94

## Changes

### 1. New `BrandLogo` Component (`src/components/BrandLogo.tsx`)
- **Logo API**: Uses [logo.clearbit.com](https://logo.clearbit.com) — a free, high-quality brand logo API
- **50+ brand mappings**: Pre-mapped domains for common brands (Amazon, Nike, Starbucks, Netflix, Spotify, Uber, Apple, Google, etc.)
- **Fallback domain guessing**: For unmapped brands, attempts `{brandname}.com` as a fallback
- **Gradient initial avatar**: When logo fails to load, shows a styled gradient circle with the brand's first letter (consistent color per brand)
- **Three size variants**: `sm` (32px), `md` (48px), `lg` (64px) for different card layouts
- **Performance**: Lazy loading (`loading="lazy"`) on all logo images
- **Accessibility**: `aria-label` and `title` attributes on all logos

### 2. Integration Across 6 Pages

| Page | Card Type | Logo Size | Placement |
|------|-----------|-----------|-----------|
| **Home** | Featured voucher cards | `lg` (64px) | Centered above brand name |
| **Marketplace** | Voucher listing cards | `lg` (64px) | Centered above brand name |
| **Exchange** | My vouchers + AI-matched | `md` (48px) | Inline next to brand name |
| **Wallet** | Active/redeemed vouchers | `md` (48px) | In header row with name |
| **Wishlist** | Wishlist item cards | `sm` (32px) | Inline before brand name |
| **ExpiryInsights** | Expiry detail cards | `sm` (32px) | Inline before brand name |

### 3. Fallback Behavior
- If the logo URL returns an error (404, CORS, etc.), the component gracefully falls back to a **gradient-colored initial avatar**
- Each brand gets a deterministic color based on its name hash, so fallbacks look consistent

## Screenshots

The brand logos appear as small, clean icons within a rounded container with a subtle border and shadow, seamlessly fitting the existing card design.

## Testing

- [x] Logos load correctly for mapped brands (Amazon, Nike, Starbucks, etc.)
- [x] Fallback avatar shows for unknown/unmapped brands
- [x] All 6 pages display logos in appropriate positions
- [x] Responsive across desktop and mobile viewports
- [x] Lazy loading works (images load as cards scroll into view)
- [x] No TypeScript errors
- [x] No console errors for failed logo loads (graceful fallback)
