### PR TITLE
feat(auth): add show/hide password toggle in authentication forms

### DIFF
--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Repeat, Mail, Lock, User } from 'lucide-react';
+import { Repeat, Mail, Lock, User, Eye, EyeOff } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 
 export default function Auth() {
@@ -9,6 +9,7 @@ export default function Auth() {
   const [fullName, setFullName] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
   const { signIn, signUp } = useAuth();
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -94,14 +95,23 @@ export default function Auth() {
               <div className="relative">
                 <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-slate-400" />
                 <input
-                  type="password"
+                  type={showPassword ? 'text' : 'password'}
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  className="w-full pl-10 pr-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-transparent transition-all"
+                  className="w-full pl-10 pr-12 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-teal-500 focus:border-transparent transition-all"
                   placeholder="Enter your password"
                   required
                   minLength={6}
                 />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 transition-colors p-1"
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  tabIndex={-1}
+                >
+                  {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+                </button>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary

Adds a show/hide password toggle to the authentication forms (Sign In and Sign Up), allowing users to verify their password while typing.

Closes #89

## Problem

The password fields in the Login and Signup forms only allow masked text input. Users cannot verify what they've typed, which can lead to input errors — especially on mobile devices or when creating complex passwords during sign up.

## Solution

Added an **Eye/EyeOff toggle button** inside the password input field in `src/components/Auth.tsx`.

### How it works

| State | Icon | Input Type | Behavior |
|-------|------|-----------|----------|
| Hidden (default) | 👁 Eye | `password` | Password is masked with dots |
| Visible | 👁‍🗨 EyeOff | `text` | Password is shown as plain text |

### Implementation details

- **Toggle state**: `showPassword` boolean controls `type="password"` vs `type="text"`
- **Icons**: Uses `Eye` and `EyeOff` from `lucide-react` (already a project dependency)
- **Accessibility**: `aria-label` toggles between "Show password" / "Hide password"
- **Tab order**: `tabIndex={-1}` on the toggle button to avoid disrupting form navigation
- **Padding**: Input `pr-12` to prevent typed text from overlapping the icon
- **Styling**: Smooth hover color transition (`text-slate-400` → `text-slate-600`)
- **Works on both forms**: Same password field is used for Sign In and Sign Up

## Testing

- [x] Eye icon visible in password field on Sign In form
- [x] Eye icon visible in password field on Sign Up form
- [x] Click toggles between masked and visible password
- [x] Toggle state resets appropriately when switching forms
- [x] No overlap between typed text and toggle icon
- [x] Accessible with screen readers (aria-label)
- [x] No TypeScript errors
